### PR TITLE
Add Tags instead of categories

### DIFF
--- a/sql-schema/variables.sql
+++ b/sql-schema/variables.sql
@@ -135,7 +135,7 @@ CREATE TABLE `cd_variables` (
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '[]',
   `user_error_message` text COMMENT '[]',
   `valence` enum('positive','negative','neutral') DEFAULT NULL COMMENT '[]',
-  `variable_category_id` tinyint(3) unsigned NOT NULL COMMENT 'Variable category ID',
+  `tags` varchar(600) DEFAULT NULL COMMENT '[Reference] Tags for categorization in multiple levels/ontologies/types/subtypes e.g. Condition, Intervention, Biomarker and going deeper the ontology level: Laboratory test, Blood test, Lipid panel, or for logical grouping e.g. Risk scores, Hormones, Medical use',
   `variance` double DEFAULT NULL COMMENT 'Variance',
   `version_first_released` varchar(255) DEFAULT NULL COMMENT 'The CureDAO version number in which the record was first released. For oldest records where the version released number is known, this field will be null.',
   `version_last_changed` varchar(255) DEFAULT NULL COMMENT 'The CureDAO version number in which the record has last changed. For records that have never been updated after their release, this field will contain the same value as the loinc.VersionFirstReleased field.',


### PR DESCRIPTION
Remove variable_category in favor of a tags Array to be able to use multiple ontology levels and grouping and categorization at the same time.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>